### PR TITLE
商品一覧表示機能

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -59,9 +59,9 @@ group :development do
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
-gem 'devise'
-gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]
-gem 'mini_magick'
-gem 'image_processing', '~> 1.2'
 gem 'active_hash'
-gem "pry-rails"
+gem 'devise'
+gem 'image_processing', '~> 1.2'
+gem 'mini_magick'
+gem 'pry-rails'
+gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,6 @@
 class ItemsController < ApplicationController
   def index
+    @item = Item.all.order("created_at DESC")
   end
 
   def new

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,6 @@
 class ItemsController < ApplicationController
   def index
-    @item = Item.all.order("created_at DESC")
+    @item = Item.all.order('created_at DESC')
   end
 
   def new
@@ -18,9 +18,8 @@ class ItemsController < ApplicationController
 
   private
 
-  
-
   def item_params
-    params.require(:item).permit(:image, :name, :info, :category_id, :sales_status_id, :shipping_fee_status_id, :prefecture_id, :scheduled_delivery_id, :price).merge(user_id: current_user.id)
+    params.require(:item).permit(:image, :name, :info, :category_id, :sales_status_id, :shipping_fee_status_id,
+                                 :prefecture_id, :scheduled_delivery_id, :price).merge(user_id: current_user.id)
   end
 end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -12,7 +12,7 @@ class Category < ActiveHash::Base
     { id: 9, name: 'ハンドメイド' },
     { id: 10, name: 'その他' }
   ]
-    # itemsテーブルとのアソシエーション
-    include ActiveHash::Associations
-    has_many :items
-  end
+  # itemsテーブルとのアソシエーション
+  include ActiveHash::Associations
+  has_many :items
+end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -4,7 +4,7 @@ class Item < ApplicationRecord
 
   # レコードとファイルを1対1の関係で紐づけるアソシエーション
   has_one_attached :image
-  
+
   # ActiveHashのモデルファイルとのアソシエーション
   extend ActiveHash::Associations::ActiveRecordExtensions
   belongs_to :category
@@ -24,6 +24,6 @@ class Item < ApplicationRecord
     validates :prefecture_id, numericality: { other_than: 0, message: "can't be blank" }
     validates :scheduled_delivery_id, numericality: { other_than: 0, message: "can't be blank" }
     validates :price, numericality: { greater_than_or_equal_to: 300, less_than_or_equal_to: 9_999_999 },
-              format: { with: /\A[0-9]+\z/ }
+                      format: { with: /\A[0-9]+\z/ }
   end
 end

--- a/app/models/prefecture.rb
+++ b/app/models/prefecture.rb
@@ -49,7 +49,7 @@ class Prefecture < ActiveHash::Base
     { id: 46, name: '鹿児島県' },
     { id: 47, name: '沖縄' }
   ]
-    # itemsテーブルとのアソシエーション
-    include ActiveHash::Associations
-    has_many :items
-  end
+  # itemsテーブルとのアソシエーション
+  include ActiveHash::Associations
+  has_many :items
+end

--- a/app/models/sales_status.rb
+++ b/app/models/sales_status.rb
@@ -8,7 +8,7 @@ class SalesStatus < ActiveHash::Base
     { id: 5, name: '傷や汚れあり' },
     { id: 6, name: '全体的に状態が悪い' }
   ]
-    # itemsテーブルとのアソシエーション
-    include ActiveHash::Associations
-    has_many :items
-  end
+  # itemsテーブルとのアソシエーション
+  include ActiveHash::Associations
+  has_many :items
+end

--- a/app/models/scheduled_delivery.rb
+++ b/app/models/scheduled_delivery.rb
@@ -5,7 +5,7 @@ class ScheduledDelivery < ActiveHash::Base
     { id: 2, name: '2~3日で発送' },
     { id: 3, name: '4~7日で発送' }
   ]
-    # itemsテーブルとのアソシエーション
-    include ActiveHash::Associations
-    has_many :items
-  end
+  # itemsテーブルとのアソシエーション
+  include ActiveHash::Associations
+  has_many :items
+end

--- a/app/models/shipping_fee_status.rb
+++ b/app/models/shipping_fee_status.rb
@@ -4,7 +4,7 @@ class ShippingFeeStatus < ActiveHash::Base
     { id: 1, name: '着払い(購入者負担)' },
     { id: 2, name: '送料込み(出品者負担)' }
   ]
-    # itemsテーブルとのアソシエーション
-    include ActiveHash::Associations
-    has_many :items
-  end
+  # itemsテーブルとのアソシエーション
+  include ActiveHash::Associations
+  has_many :items
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,7 +3,7 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
-  
+
   # アソシエーションの設定
   has_many :items
 

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -129,6 +129,7 @@
     <ul class='item-lists'>
 
       <%# 商品が存在する場合%>
+      <% if @item.present? %>
       <% @item.each do | item | %>
       <li class='list'>
         <%= link_to do %>
@@ -159,7 +160,8 @@
       <% end %>
       <%# //商品が存在する場合 %>
 
-      <%# 商品がない場合のダミー表示 %>
+      <%# 商品が存在しない場合のダミー表示 %>
+      <% else %>
       <li class='list'>
         <%= link_to '#' do %>
         <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
@@ -177,7 +179,8 @@
         </div>
         <% end %>
       </li>
-      <%# //商品がない場合のダミー表示機能 %>
+      <% end %>
+      <%# //商品が存在しない場合のダミー表示機能 %>
     </ul>
   </div>
   <%# /商品一覧 %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -148,7 +148,7 @@
             <%= item.name %>
           </h3>
           <div class='item-price'>
-            <span><%= item.price %>円<br><%= item.shipping_fee_status %></span>
+            <span><%= item.price %>円<br><%= item.shipping_fee_status.name %></span>
             <div class='star-btn'>
               <%= image_tag "star.png", class:"star-icon" %>
               <span class='star-count'>0</span>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -128,25 +128,26 @@
     </div>
     <ul class='item-lists'>
 
-      <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+      <%# 商品が存在する場合%>
+      <% @item.each do | item | %>
       <li class='list'>
-        <%= link_to "#" do %>
+        <%= link_to do %>
         <div class='item-img-content'>
-          <%= image_tag "item-sample.png", class: "item-img" %>
+          <%= image_tag item.image, class: "item-img" %>
 
-          <%# 商品が売れていればsold outを表示しましょう %>
+          <%# 商品が売れた際のsold outの表示 %>
           <div class='sold-out'>
             <span>Sold Out!!</span>
           </div>
-          <%# //商品が売れていればsold outを表示しましょう %>
+          <%# //商品が売れた際のsold outの表示 %>
 
         </div>
         <div class='item-info'>
           <h3 class='item-name'>
-            <%= "商品名" %>
+            <%= item.name %>
           </h3>
           <div class='item-price'>
-            <span><%= "販売価格" %>円<br><%= '配送料負担' %></span>
+            <span><%= item.price %>円<br><%= item.shipping_fee_status %></span>
             <div class='star-btn'>
               <%= image_tag "star.png", class:"star-icon" %>
               <span class='star-count'>0</span>
@@ -155,10 +156,10 @@
         </div>
         <% end %>
       </li>
-      <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+      <% end %>
+      <%# //商品が存在する場合 %>
 
-      <%# 商品がない場合は以下のダミー商品が表示されるようにしましょう %>
-      <%# 商品がある場合は表示されないようにしましょう %>
+      <%# 商品がない場合のダミー表示 %>
       <li class='list'>
         <%= link_to '#' do %>
         <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
@@ -176,8 +177,7 @@
         </div>
         <% end %>
       </li>
-      <%# //商品がある場合は表示されないようにしましょう %>
-      <%# //商品がない場合は以下のダミー商品が表示されるようにしましょう %>
+      <%# //商品がない場合のダミー表示機能 %>
     </ul>
   </div>
   <%# /商品一覧 %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,5 @@ Rails.application.routes.draw do
 
   # /itemsのパスに対応するルーティング
   resources :items, only: [ :new, :create ]
-
 end
 # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,7 @@ Rails.application.routes.draw do
   # トップページビュー表示のルーティング
   root to: 'items#index'
 
-  # itemsのパスに対応するルーティング
+  # /itemsのパスに対応するルーティング
   resources :items, only: [ :new, :create ]
 end
 # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,6 @@ Rails.application.routes.draw do
   root to: 'items#index'
 
   # /itemsのパスに対応するルーティング
-  resources :items, only: [ :new, :create ]
-
+  resources :items, only: %i[new create]
 end
 # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html

--- a/db/migrate/20211002035432_create_active_storage_tables.active_storage.rb
+++ b/db/migrate/20211002035432_create_active_storage_tables.active_storage.rb
@@ -10,7 +10,7 @@ class CreateActiveStorageTables < ActiveRecord::Migration[5.2]
       t.string   :checksum,   null: false
       t.datetime :created_at, null: false
 
-      t.index [ :key ], unique: true
+      t.index [:key], unique: true
     end
 
     create_table :active_storage_attachments do |t|
@@ -20,7 +20,8 @@ class CreateActiveStorageTables < ActiveRecord::Migration[5.2]
 
       t.datetime :created_at, null: false
 
-      t.index [ :record_type, :record_id, :name, :blob_id ], name: "index_active_storage_attachments_uniqueness", unique: true
+      t.index %i[record_type record_id name blob_id], name: 'index_active_storage_attachments_uniqueness',
+                                                      unique: true
       t.foreign_key :active_storage_blobs, column: :blob_id
     end
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,62 +10,62 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_10_02_035432) do
-
-  create_table "active_storage_attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.string "name", null: false
-    t.string "record_type", null: false
-    t.bigint "record_id", null: false
-    t.bigint "blob_id", null: false
-    t.datetime "created_at", null: false
-    t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
-    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
+ActiveRecord::Schema.define(version: 20_211_002_035_432) do
+  create_table 'active_storage_attachments', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8', force: :cascade do |t|
+    t.string 'name', null: false
+    t.string 'record_type', null: false
+    t.bigint 'record_id', null: false
+    t.bigint 'blob_id', null: false
+    t.datetime 'created_at', null: false
+    t.index ['blob_id'], name: 'index_active_storage_attachments_on_blob_id'
+    t.index %w[record_type record_id name blob_id], name: 'index_active_storage_attachments_uniqueness',
+                                                    unique: true
   end
 
-  create_table "active_storage_blobs", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.string "key", null: false
-    t.string "filename", null: false
-    t.string "content_type"
-    t.text "metadata"
-    t.bigint "byte_size", null: false
-    t.string "checksum", null: false
-    t.datetime "created_at", null: false
-    t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+  create_table 'active_storage_blobs', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8', force: :cascade do |t|
+    t.string 'key', null: false
+    t.string 'filename', null: false
+    t.string 'content_type'
+    t.text 'metadata'
+    t.bigint 'byte_size', null: false
+    t.string 'checksum', null: false
+    t.datetime 'created_at', null: false
+    t.index ['key'], name: 'index_active_storage_blobs_on_key', unique: true
   end
 
-  create_table "items", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.string "name", null: false
-    t.text "info", null: false
-    t.integer "category_id", null: false
-    t.integer "sales_status_id", null: false
-    t.integer "shipping_fee_status_id", null: false
-    t.integer "prefecture_id", null: false
-    t.integer "scheduled_delivery_id", null: false
-    t.integer "price", null: false
-    t.bigint "user_id", null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.index ["user_id"], name: "index_items_on_user_id"
+  create_table 'items', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8', force: :cascade do |t|
+    t.string 'name', null: false
+    t.text 'info', null: false
+    t.integer 'category_id', null: false
+    t.integer 'sales_status_id', null: false
+    t.integer 'shipping_fee_status_id', null: false
+    t.integer 'prefecture_id', null: false
+    t.integer 'scheduled_delivery_id', null: false
+    t.integer 'price', null: false
+    t.bigint 'user_id', null: false
+    t.datetime 'created_at', precision: 6, null: false
+    t.datetime 'updated_at', precision: 6, null: false
+    t.index ['user_id'], name: 'index_items_on_user_id'
   end
 
-  create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.string "nickname", null: false
-    t.string "email", default: "", null: false
-    t.string "encrypted_password", default: "", null: false
-    t.string "last_name", null: false
-    t.string "first_name", null: false
-    t.string "last_name_kana", null: false
-    t.string "first_name_kana", null: false
-    t.date "birthday", null: false
-    t.string "reset_password_token"
-    t.datetime "reset_password_sent_at"
-    t.datetime "remember_created_at"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.index ["email"], name: "index_users_on_email", unique: true
-    t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
+  create_table 'users', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8', force: :cascade do |t|
+    t.string 'nickname', null: false
+    t.string 'email', default: '', null: false
+    t.string 'encrypted_password', default: '', null: false
+    t.string 'last_name', null: false
+    t.string 'first_name', null: false
+    t.string 'last_name_kana', null: false
+    t.string 'first_name_kana', null: false
+    t.date 'birthday', null: false
+    t.string 'reset_password_token'
+    t.datetime 'reset_password_sent_at'
+    t.datetime 'remember_created_at'
+    t.datetime 'created_at', precision: 6, null: false
+    t.datetime 'updated_at', precision: 6, null: false
+    t.index ['email'], name: 'index_users_on_email', unique: true
+    t.index ['reset_password_token'], name: 'index_users_on_reset_password_token', unique: true
   end
 
-  add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
-  add_foreign_key "items", "users"
+  add_foreign_key 'active_storage_attachments', 'active_storage_blobs', column: 'blob_id'
+  add_foreign_key 'items', 'users'
 end

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -10,6 +10,6 @@ FactoryBot.define do
     scheduled_delivery_id { 1 }
     price { 300 }
 
-    association :user 
+    association :user
   end
 end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Item, type: :model do
     @item = FactoryBot.build(:item)
   end
 
-  describe '商品出品' do
+  describe '商品出品機能' do
     context '商品が出品できるとき' do
       it 'image, name, info, category_id, sales_status_id, shipping_fee_status_id, prefecture_id, scheduled_delivery_id, priceが正しく存在すれば出品できる' do
         expect(@item).to be_valid
@@ -14,11 +14,10 @@ RSpec.describe Item, type: :model do
 
     context '商品が出品できないとき' do
       it '商品画像が空では出品できない' do
-        @item.image = nil 
+        @item.image = nil
         @item.valid?
         expect(@item.errors.full_messages).to include "Image can't be blank"
       end
-
       it '商品名が空では出品できない' do
         @item.name = ''
         @item.valid?
@@ -27,7 +26,7 @@ RSpec.describe Item, type: :model do
       it '商品名が４０字以上では出品できない' do
         @item.name = 'a' * 41
         @item.valid?
-        expect(@item.errors.full_messages).to include "Name is too long (maximum is 40 characters)"
+        expect(@item.errors.full_messages).to include 'Name is too long (maximum is 40 characters)'
       end
       it '商品の説明が空では出品できない' do
         @item.info = ''
@@ -37,7 +36,7 @@ RSpec.describe Item, type: :model do
       it '商品の説明が１,０００文字以上では出品できない' do
         @item.info = 'a' * 1001
         @item.valid?
-        expect(@item.errors.full_messages).to include "Info is too long (maximum is 1000 characters)"
+        expect(@item.errors.full_messages).to include 'Info is too long (maximum is 1000 characters)'
       end
       it 'カテゴリーが---では出品できない' do
         @item.category_id = '0'
@@ -67,30 +66,29 @@ RSpec.describe Item, type: :model do
       it '販売価格が空では出品できない' do
         @item.price = ''
         @item.valid?
-        expect(@item.errors.full_messages).to include "Price is not a number"
+        expect(@item.errors.full_messages).to include 'Price is not a number'
       end
       it '販売価格が¥300以下では出品できない' do
         @item.price = '299'
         @item.valid?
-        expect(@item.errors.full_messages).to include "Price must be greater than or equal to 300"
+        expect(@item.errors.full_messages).to include 'Price must be greater than or equal to 300'
       end
       it '販売価格が¥9,999,999以上では出品できない' do
         @item.price = '10000000'
         @item.valid?
-        expect(@item.errors.full_messages).to include  "Price must be less than or equal to 9999999"
+        expect(@item.errors.full_messages).to include 'Price must be less than or equal to 9999999'
       end
       it '半角数字以外の値が含まれている場合は保存できない' do
         @item.price = 'aあ１'
         @item.valid?
-        expect(@item.errors.full_messages).to include  "Price is not a number"
+        expect(@item.errors.full_messages).to include 'Price is not a number'
       end
       it 'ユーザー情報が紐づいていないと保存できない' do
         @item.user = nil
         @item.valid?
-        expect(@item.errors.full_messages).to include  "User must exist"
+        expect(@item.errors.full_messages).to include 'User must exist'
       end
     end
   end
   # pending "add some examples to (or delete) #{__FILE__}"
 end
-

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe User, type: :model do
       it 'メールアドレスに@を含まない場合は登録できない' do
         @user.email = '0'
         @user.valid?
-        expect(@user.errors.full_messages).to include("Email is invalid")
+        expect(@user.errors.full_messages).to include('Email is invalid')
       end
 
       it '重複したemailが存在する場合は登録できない' do


### PR DESCRIPTION
# What
・商品一覧機能の実装
[![商品一覧機能の実装](https://i.gyazo.com/6beb9974319475cf5ed2ac4b2a803b75.gif)](https://gyazo.com/6beb9974319475cf5ed2ac4b2a803b75)
・商品が存在しない場合のダミー表示分岐
[![商品が存在しない場合のダミー表示分岐](https://i.gyazo.com/ace7d4f95eac87e466c6836cdaeeec92.gif)](https://gyazo.com/ace7d4f95eac87e466c6836cdaeeec92)

# Why
トップページに出品中商品を置き、すぐに観覧させるにより購買意欲を高めるためです！